### PR TITLE
Remove duplicated sections about release tagging

### DIFF
--- a/release_guide/10/Branching_and_Tagging.adoc
+++ b/release_guide/10/Branching_and_Tagging.adoc
@@ -147,8 +147,13 @@ popd
 
 == Tagging JBoss Tools
 
+Create tags for build-related JBT repositories.
+
+Once cloned to disk, this script will create the tags if run from the location with your git clones. If tags exist, no new tag will be created.
+
 [source,bash]
 ----
+
 # if not already cloned, the do this:
 git clone https://github.com/jbosstools/jbosstools-build
 git clone https://github.com/jbosstools/jbosstools-build-ci
@@ -162,26 +167,35 @@ git clone https://github.com/jbosstools/jbosstools-versionwatch
 # maven-plugins does not get released/branched the same as other projects, but tag it anyway
 # download.jboss.org tag might not be valid as tweaks to ide-config.properties happen frequently
 
-jbt_branch=master
-version=4.4.0.Alpha1
+version_jbt=4.4.3.AM2
+if [[ ${version_jbt} == *".Final" ]]; then
+  jbt_branch=jbosstools-4.4.3.x
+else
+  jbt_branch=master
+fi
+cd ~/tru # ~
 for d in build build-ci build-sites devdoc discovery download.jboss.org maven-plugins versionwatch; do
   echo "====================================================================="
-  echo "Tagging jbosstools-${d} from branch ${jbt_branch} as tag ${version}..."
+  echo "Tagging jbosstools-${d} from branch ${jbt_branch} as tag ${version_jbt}..."
   pushd jbosstools-${d}
   git fetch origin ${jbt_branch}
-  git tag jbosstools-${version} FETCH_HEAD
-  git push origin jbosstools-${version}
-  echo ">>> https://github.com/jbosstools/jbosstools-${d}/tree/jbosstools-${version}"
+  git tag jbosstools-${version_jbt} FETCH_HEAD
+  git push origin jbosstools-${version_jbt}
+  echo ">>> https://github.com/jbosstools/jbosstools-${d}/tree/jbosstools-${version_jbt}"
   popd >/dev/null
   echo "====================================================================="
   echo ""
 done
+
 ----
 
 == Tagging Developer Studio
 
+Once cloned to disk, this script will create the tags if run from the location with your git clones. If tags exist, no new tag will be created.
+
 [source,bash]
 ----
+
 # if not already cloned, the do this:
 git clone https://github.com/jbdevstudio/jbdevstudio-product
 git clone https://github.com/jbdevstudio/jbdevstudio-ci
@@ -189,18 +203,24 @@ git clone https://github.com/jbdevstudio/jbdevstudio-website
 git clone https://github.com/jbdevstudio/jbdevstudio-artwork
 git clone https://github.com/jbdevstudio/jbdevstudio-devdoc
 
-jbt_branch=master
-version=10.0.0.Alpha1
+version_ds=10.3.0.AM2
+if [[ ${version_ds} == *".GA" ]]; then
+  jbt_branch=jbosstools-4.4.3.x
+else
+  jbt_branch=master
+fi
+cd ~/truu # ~
 for d in product ci website artwork devdoc; do
   echo "====================================================================="
-  echo "Tagging jbdevstudio-${d} from branch ${jbt_branch} as tag ${version}..."
+  echo "Tagging jbdevstudio-${d} from branch ${jbt_branch} as tag ${version_ds}..."
   pushd jbdevstudio-${d}
   git fetch origin ${jbt_branch}
-  git tag jbdevstudio-${version} FETCH_HEAD
-  git push origin jbdevstudio-${version}
-  echo ">>> https://github.com/jbdevstudio/jbdevstudio-${d}/tree/jbdevstudio-${version}"
+  git tag jbdevstudio-${version_ds} FETCH_HEAD
+  git push origin jbdevstudio-${version_ds}
+  echo ">>> https://github.com/jbdevstudio/jbdevstudio-${d}/tree/jbdevstudio-${version_ds}"
   popd >/dev/null
   echo "====================================================================="
   echo ""
 done
+
 ----

--- a/release_guide/10/JBDS_Release.adoc
+++ b/release_guide/10/JBDS_Release.adoc
@@ -302,41 +302,10 @@ popd
 Commit changes and submit PR, eg., https://github.com/jbosstools/jbosstools-website/pull/651 or https://github.com/jbosstools/jbosstools-website/pull/664
 
 
-== Tag JBDS Git
+== Tagging Developer Studio
 
-Once cloned to disk, this script will create the tags if run from the location with your git clones. If tags exist, no new tag will be created.
+See Branching_and_Tagging.adoc
 
-[source,bash]
-----
-
-# if not already cloned, the do this:
-git clone https://github.com/jbdevstudio/jbdevstudio-product
-git clone https://github.com/jbdevstudio/jbdevstudio-ci
-git clone https://github.com/jbdevstudio/jbdevstudio-website
-git clone https://github.com/jbdevstudio/jbdevstudio-artwork
-git clone https://github.com/jbdevstudio/jbdevstudio-devdoc
-
-version_ds=10.3.0.AM2
-if [[ ${version_ds} == *".GA" ]]; then
-  jbt_branch=jbosstools-4.4.3.x
-else
-  jbt_branch=master
-fi
-cd ~/truu # ~
-for d in product ci website artwork devdoc; do
-  echo "====================================================================="
-  echo "Tagging jbdevstudio-${d} from branch ${jbt_branch} as tag ${version_ds}..."
-  pushd jbdevstudio-${d}
-  git fetch origin ${jbt_branch}
-  git tag jbdevstudio-${version_ds} FETCH_HEAD
-  git push origin jbdevstudio-${version_ds}
-  echo ">>> https://github.com/jbdevstudio/jbdevstudio-${d}/tree/jbdevstudio-${version_ds}"
-  popd >/dev/null
-  echo "====================================================================="
-  echo ""
-done
-
-----
 
 == Smoke test the release
 

--- a/release_guide/10/JBT_Release.adoc
+++ b/release_guide/10/JBT_Release.adoc
@@ -500,53 +500,14 @@ Before notifying team of release, must check for obvious problems. Any failure t
 4. Check log for errors, start an example project or run a quickstart, check log again
 5. Check to make sure "Windows > Prefs > Install/Update > Available Software Sites" shows you what you expect to see
 
-== Tag JBT Git
+== Tagging JBoss Tools
 
-=== Create tags for build-related repositories
+See Branching_and_Tagging.adoc
 
-Once cloned to disk, this script will create the tags if run from the location with your git clones. If tags exist, no new tag will be created.
 
-[source,bash]
-----
+== Tagging Developer Studio
 
-# if not already cloned, the do this:
-git clone https://github.com/jbosstools/jbosstools-build
-git clone https://github.com/jbosstools/jbosstools-build-ci
-git clone https://github.com/jbosstools/jbosstools-build-sites
-git clone https://github.com/jbosstools/jbosstools-devdoc
-git clone https://github.com/jbosstools/jbosstools-discovery
-git clone https://github.com/jbosstools/jbosstools-download.jboss.org
-git clone https://github.com/jbosstools/jbosstools-maven-plugins
-git clone https://github.com/jbosstools/jbosstools-versionwatch
-
-# maven-plugins does not get released/branched the same as other projects, but tag it anyway
-# download.jboss.org tag might not be valid as tweaks to ide-config.properties happen frequently
-
-version_jbt=4.4.3.AM2
-if [[ ${version_jbt} == *".Final" ]]; then
-  jbt_branch=jbosstools-4.4.3.x
-else
-  jbt_branch=master
-fi
-cd ~/tru # ~
-for d in build build-ci build-sites devdoc discovery download.jboss.org maven-plugins versionwatch; do
-  echo "====================================================================="
-  echo "Tagging jbosstools-${d} from branch ${jbt_branch} as tag ${version_jbt}..."
-  pushd jbosstools-${d}
-  git fetch origin ${jbt_branch}
-  git tag jbosstools-${version_jbt} FETCH_HEAD
-  git push origin jbosstools-${version_jbt}
-  echo ">>> https://github.com/jbosstools/jbosstools-${d}/tree/jbosstools-${version_jbt}"
-  popd >/dev/null
-  echo "====================================================================="
-  echo ""
-done
-
-----
-
-== Tag JBDS Git
-
-See JBDS_Release.adoc
+See Branching_and_Tagging.adoc
 
 
 == Notify Team Lead(s)


### PR DESCRIPTION
I noticed that the "tagging" sections were duplicated in another document... This change merges the tagging sections from the *_Release documents into the Branching_and_Tagging document.
